### PR TITLE
Dependency inject over user agents set by lotus client

### DIFF
--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/filecoin-project/lotus/node/modules/lp2p"
 	"io/ioutil"
 	"path/filepath"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/filecoin-project/lotus/node"
 	lotusmodules "github.com/filecoin-project/lotus/node/modules"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
+	"github.com/filecoin-project/lotus/node/modules/lp2p"
 	"github.com/filecoin-project/lotus/node/repo"
 	"github.com/mitchellh/go-homedir"
 	"github.com/multiformats/go-multiaddr"
@@ -262,7 +262,7 @@ Note that jobs are not persisted between restarts of the daemon. See
 			node.Override(new(dtypes.Bootstrapper), isBootstrapper),
 			node.Override(new(dtypes.ShutdownChan), shutdown),
 			node.Base(),
-			node.Override(new(*lp2p.RawHost), modules.NewLibp2pConfig),
+			node.Override(new(lp2p.RawHost), modules.NewHost),
 			node.Repo(r),
 
 			node.Override(new(dtypes.UniversalBlockstore), modules.NewCachingUniversalBlockstore),

--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/filecoin-project/lotus/node/modules/lp2p"
 	"io/ioutil"
 	"path/filepath"
 
@@ -261,6 +262,7 @@ Note that jobs are not persisted between restarts of the daemon. See
 			node.Override(new(dtypes.Bootstrapper), isBootstrapper),
 			node.Override(new(dtypes.ShutdownChan), shutdown),
 			node.Base(),
+			node.Override(new(*lp2p.RawHost), modules.NewLibp2pConfig),
 			node.Repo(r),
 
 			node.Override(new(dtypes.UniversalBlockstore), modules.NewCachingUniversalBlockstore),

--- a/lens/lily/modules/config.go
+++ b/lens/lily/modules/config.go
@@ -31,7 +31,7 @@ func NewQueueCatalog(mctx helpers.MetricsCtx, lc fx.Lifecycle, cfg *config.Conf)
 	return distributed.NewCatalog(cfg.Queue)
 }
 
-func NewLibp2pConfig(mctx helpers.MetricsCtx, lc fx.Lifecycle, params lp2p.P2PHostIn) (*host.Host, error) {
+func NewHost(mctx helpers.MetricsCtx, lc fx.Lifecycle, params lp2p.P2PHostIn) (*host.Host, error) {
 	pkey := params.Peerstore.PrivKey(params.ID)
 	if pkey == nil {
 		return nil, fmt.Errorf("missing private key for node ID: %s", params.ID.Pretty())

--- a/lens/lily/modules/config.go
+++ b/lens/lily/modules/config.go
@@ -1,7 +1,14 @@
 package modules
 
 import (
+	"context"
+	"fmt"
+	"github.com/libp2p/go-libp2p/core/host"
+
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/node/modules/helpers"
+	"github.com/filecoin-project/lotus/node/modules/lp2p"
+	"github.com/libp2p/go-libp2p"
 	"go.uber.org/fx"
 
 	"github.com/filecoin-project/lily/chain/indexer/distributed"
@@ -22,4 +29,35 @@ func LoadConf(path string) func(mctx helpers.MetricsCtx, lc fx.Lifecycle) (*conf
 
 func NewQueueCatalog(mctx helpers.MetricsCtx, lc fx.Lifecycle, cfg *config.Conf) (*distributed.Catalog, error) {
 	return distributed.NewCatalog(cfg.Queue)
+}
+
+func NewLibp2pConfig(mctx helpers.MetricsCtx, lc fx.Lifecycle, params lp2p.P2PHostIn) (*host.Host, error) {
+	pkey := params.Peerstore.PrivKey(params.ID)
+	if pkey == nil {
+		return nil, fmt.Errorf("missing private key for node ID: %s", params.ID.Pretty())
+	}
+
+	opts := []libp2p.Option{
+		libp2p.Identity(pkey),
+		libp2p.Peerstore(params.Peerstore),
+		libp2p.NoListenAddrs,
+		libp2p.Ping(true),
+		libp2p.UserAgent("lily-" + build.UserVersion()),
+	}
+	for _, o := range params.Opts {
+		opts = append(opts, o...)
+	}
+
+	h, err := libp2p.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	lc.Append(fx.Hook{
+		OnStop: func(ctx context.Context) error {
+			return h.Close()
+		},
+	})
+
+	return &h, nil
 }


### PR DESCRIPTION
Getting my head around the lily codebase. Looking at https://github.com/filecoin-project/lily/issues/692

There's a few potential approaches to solving this:
1. Dependency inject the Host object to have it replace the existing Host object in LibP2P. I'm not sure if this will work, since the node would already have been created at this point. And it can't be added before the creation of the node, as that creation will override the injected Host object
2. Turn off s.enableLibP2pNode and instantiate your own libp2p Options. The below happens in node.Base()
```
		ApplyIf(func(s *Settings) bool { return s.enableLibp2pNode },
			LibP2P,
		),
```
This approach seems to be quite heavyweight. There are a lot of options that come included using s.enableLibP2pNode. However, it does give us full control and ability to configure the networking aspect of Lily. Does Lily want to be responsible for that?
3. Ask Lotus to make the user agent configurable. Allow us to pass a user-agent string as a configuration knob similar to s.enableLibP2pNode. This depends on whether lotus uses the user agent for any substantial logic or ACLs etc.